### PR TITLE
fix: Ensure all components are available in docs live code scope

### DIFF
--- a/src/pages/docs/docs.page.tsx
+++ b/src/pages/docs/docs.page.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Alert, Loader } from '../../components';
+import * as AllComponents from '../../components';
+import * as AppStudio from 'app-studio';
 import { Horizontal, Vertical } from 'app-studio';
 import { loadDocs } from '../../docsLoader';
 import * as runtime from 'react/jsx-runtime';
@@ -18,7 +20,7 @@ const DocsPage = () => {
     code: (props: any) => {
       const { className = '', children } = props;
       const language = className.replace('language-', '');
-      return <LiveCode code={children} language={language} scope={{ Alert }} />;
+      return <LiveCode code={children} language={language} scope={{ ...AllComponents, ...AppStudio, React }} />;
     },
   };
 


### PR DESCRIPTION
Previously, the LiveCode component in the documentation pages had a limited scope, often only including the 'Alert' component. This caused other components used in MDX examples not to render correctly.

This change modifies `src/pages/docs/docs.page.tsx` to import all components from `src/components/index.tsx` and `app-studio`, and includes them in the scope provided to `LiveCode`. This allows all documented components to render correctly in live examples.