### PR TITLE
feat: add audio recording input with waveform

### DIFF
--- a/src/components/AudioInput/AudioInput.tsx
+++ b/src/components/AudioInput/AudioInput.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useAudioRecording } from '../../hooks/useAudioRecording';
+import { AudioWaveform } from './AudioWaveform';
+import { AudioInputProps } from './AudioInput/AudioInput.props';
+
+export function AudioInput({ onAudio }: AudioInputProps) {
+  const {
+    recording,
+    paused,
+    audioBlob,
+    analyserNode,
+    startRecording,
+    stopRecording,
+    pauseRecording,
+    resumeRecording,
+    resetRecording,
+  } = useAudioRecording();
+
+  useEffect(() => {
+    if (audioBlob && onAudio) {
+      const file = new File([audioBlob], 'recording.webm', {
+        type: audioBlob.type,
+      });
+      onAudio(file);
+    }
+  }, [audioBlob, onAudio]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && onAudio) {
+      onAudio(file);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input type="file" accept="audio/*" onChange={handleFileChange} />
+      {recording && (
+        <AudioWaveform analyserNode={analyserNode} isPaused={paused} />
+      )}
+      <div className="flex gap-2">
+        {!recording && (
+          <button
+            type="button"
+            onClick={startRecording}
+            className="px-2 py-1 border"
+          >
+            Record
+          </button>
+        )}
+        {recording && (
+          <>
+            <button
+              type="button"
+              onClick={paused ? resumeRecording : pauseRecording}
+              className="px-2 py-1 border"
+            >
+              {paused ? 'Resume' : 'Pause'}
+            </button>
+            <button
+              type="button"
+              onClick={stopRecording}
+              className="px-2 py-1 border"
+            >
+              Stop
+            </button>
+            <button
+              type="button"
+              onClick={resetRecording}
+              className="px-2 py-1 border"
+            >
+              Reset
+            </button>
+          </>
+        )}
+      </div>
+      {audioBlob && !recording && (
+        <audio controls src={URL.createObjectURL(audioBlob)} className="mt-2" />
+      )}
+    </div>
+  );
+}
+
+export default AudioInput;

--- a/src/components/AudioInput/AudioInput/AudioInput.props.ts
+++ b/src/components/AudioInput/AudioInput/AudioInput.props.ts
@@ -1,0 +1,3 @@
+export interface AudioInputProps {
+  onAudio?: (file: File) => void;
+}

--- a/src/components/AudioInput/AudioWaveform.tsx
+++ b/src/components/AudioInput/AudioWaveform.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useRef, useState, startTransition } from 'react';
+import { clsx } from 'clsx';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+interface AudioWaveformProps {
+  analyserNode: AnalyserNode | null;
+  isPaused: boolean;
+}
+
+export function AudioWaveform({ analyserNode, isPaused }: AudioWaveformProps) {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const MAX_BARS = 60;
+  const resolution = 32; // ms
+  const scalingFactor = 300;
+  const [bars, setBars] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!analyserNode) {
+      setBars(Array(MAX_BARS).fill(-1));
+      return;
+    }
+    const bufferLength = analyserNode.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+
+    const captureAmplitude = () => {
+      analyserNode.getByteTimeDomainData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < bufferLength; i++) {
+        const sample = (dataArray[i] - 128) / 128;
+        sum += sample * sample;
+      }
+      const rms = Math.sqrt(sum / bufferLength);
+      startTransition(() => {
+        setBars((prev) => {
+          const newBars = [...prev, rms];
+          const slicedBars = newBars.slice(-MAX_BARS);
+          if (slicedBars.length < MAX_BARS) {
+            return [
+              ...Array(MAX_BARS - slicedBars.length).fill(-1),
+              ...slicedBars,
+            ];
+          }
+          return slicedBars;
+        });
+      });
+    };
+
+    intervalRef.current = setInterval(captureAmplitude, resolution);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [analyserNode]);
+
+  return (
+    <div className="mt-4 flex h-8 items-center gap-[1px] md:mt-5 max-w-[200px] w-full">
+      {bars.map((amplitude, index) => (
+        <div
+          key={index}
+          className={clsx(
+            'w-[2px]',
+            isPaused
+              ? 'bg-gray-100'
+              : amplitude >= 0
+              ? 'bg-gray-600'
+              : 'bg-gray-200'
+          )}
+          style={{ height: `${clamp(amplitude * scalingFactor, 2, 32)}px` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/AudioInput/index.ts
+++ b/src/components/AudioInput/index.ts
@@ -1,0 +1,1 @@
+export * from './AudioInput';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,7 @@
 export * from './Accordion/Accordion';
 export * from './Alert/Alert';
 export * from './AspectRatio/AspectRatio';
+export * from './AudioInput/AudioInput';
 export * from './Avatar/Avatar';
 export * from './Badge/Badge';
 export * from './Button/Button';
@@ -64,6 +65,7 @@ export { default as AgentEval } from './adk/AgentEval/AgentEval';
 export * from './Accordion/Accordion/Accordion.props';
 export * from './Alert/Alert/Alert.props';
 export * from './AspectRatio/AspectRatio/AspectRatio.props';
+export * from './AudioInput/AudioInput/AudioInput.props';
 export * from './Avatar/Avatar/Avatar.props';
 export * from './Badge/Badge/Badge.props';
 export * from './Button/Button/Button.props';

--- a/src/hooks/useAudioRecording.ts
+++ b/src/hooks/useAudioRecording.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useAudioRecording() {
+  const [recording, setRecording] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [analyserNode, setAnalyserNode] = useState<AnalyserNode | null>(null);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      if (mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop();
+      }
+      mediaRecorderRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
+    }
+    if (analyserRef.current) {
+      analyserRef.current.disconnect();
+      analyserRef.current = null;
+    }
+    setAnalyserNode(null);
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    cleanup();
+    setError(null);
+    setDuration(0);
+    chunksRef.current = [];
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: 'audio/webm',
+      });
+      mediaRecorderRef.current = mediaRecorder;
+      const audioContext = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
+      audioContextRef.current = audioContext;
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      analyser.smoothingTimeConstant = 0.8;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+      setAnalyserNode(analyser);
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        setAudioBlob(blob);
+      };
+      mediaRecorder.start();
+      setRecording(true);
+      setPaused(false);
+      timerRef.current = setInterval(() => {
+        setDuration((d) => d + 1);
+      }, 1000);
+    } catch {
+      setError('Microphone access denied or unavailable.');
+      cleanup();
+    }
+  }, [cleanup]);
+
+  const stopRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state !== 'inactive'
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+    setRecording(false);
+    setPaused(false);
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const pauseRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === 'recording'
+    ) {
+      mediaRecorderRef.current.pause();
+      setPaused(true);
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, []);
+
+  const resumeRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === 'paused'
+    ) {
+      mediaRecorderRef.current.resume();
+      setPaused(false);
+      if (!timerRef.current) {
+        timerRef.current = setInterval(() => {
+          setDuration((d) => d + 1);
+        }, 1000);
+      }
+    }
+  }, []);
+
+  const resetRecording = useCallback(() => {
+    cleanup();
+    setRecording(false);
+    setPaused(false);
+    setAudioBlob(null);
+    setDuration(0);
+    setError(null);
+    chunksRef.current = [];
+  }, [cleanup]);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  return {
+    recording,
+    paused,
+    audioBlob,
+    analyserNode,
+    duration,
+    error,
+    startRecording,
+    stopRecording,
+    pauseRecording,
+    resumeRecording,
+    resetRecording,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add `AudioInput` component that records or uploads audio and shows live waveform
- expose `useAudioRecording` hook for capturing audio with controls
- export `AudioInput` from component index

## Testing
- `npm run lint`
- `npm run test:unwatch -- src/__tests__/title.test.tsx` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e5a0d548832b85a8bdb6bcb0f1b1