### PR TITLE
feat: add audio recording with waveform

### DIFF
--- a/src/components/ChatInput/AudioRecorder.tsx
+++ b/src/components/ChatInput/AudioRecorder.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { Horizontal, View } from 'app-studio';
+import { MicrophoneIcon, StopIcon } from '../Icon/Icon';
+import { AudioWaveform } from './AudioWaveform';
+import { useAudioRecording } from './useAudioRecording';
+
+interface AudioRecorderProps {
+  onRecordingComplete: (file: File) => void;
+  onRecordingStart?: () => void;
+  views?: { button?: any };
+}
+
+export const AudioRecorder: React.FC<AudioRecorderProps> = ({
+  onRecordingComplete,
+  onRecordingStart,
+  views = {},
+}) => {
+  const {
+    recording,
+    paused,
+    audioBlob,
+    analyserNode,
+    startRecording,
+    stopRecording,
+  } = useAudioRecording();
+
+  useEffect(() => {
+    if (audioBlob) {
+      const file = new File([audioBlob], `recording-${Date.now()}.webm`, {
+        type: 'audio/webm',
+      });
+      onRecordingComplete(file);
+    }
+  }, [audioBlob, onRecordingComplete]);
+
+  const handleStart = () => {
+    startRecording();
+    onRecordingStart?.();
+  };
+
+  return (
+    <Horizontal alignItems="center" gap={4}>
+      <View
+        as="button"
+        type="button"
+        onClick={recording ? stopRecording : handleStart}
+        height="40px"
+        width="40px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        backgroundColor={recording ? 'theme.error' : 'color.gray.100'}
+        color={recording ? 'color.white' : 'color.gray.600'}
+        borderRadius="50%"
+        border="none"
+        cursor="pointer"
+        _hover={{
+          backgroundColor: recording ? 'color.red.600' : 'color.gray.200',
+        }}
+        {...views.button}
+      >
+        {recording ? (
+          <StopIcon widthHeight={16} color="currentColor" filled={false} />
+        ) : (
+          <MicrophoneIcon
+            widthHeight={16}
+            color="currentColor"
+            filled={false}
+          />
+        )}
+      </View>
+      {recording && (
+        <AudioWaveform analyserNode={analyserNode} isPaused={paused} />
+      )}
+    </Horizontal>
+  );
+};

--- a/src/components/ChatInput/AudioWaveform.tsx
+++ b/src/components/ChatInput/AudioWaveform.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useRef, useState, startTransition } from 'react';
+import { clsx } from 'clsx';
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+interface AudioWaveformProps {
+  analyserNode: AnalyserNode | null;
+  isPaused: boolean;
+}
+
+export const AudioWaveform: React.FC<AudioWaveformProps> = ({
+  analyserNode,
+  isPaused,
+}) => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const MAX_BARS = 60;
+  const resolution = 32; // ms
+  const scalingFactor = 300;
+  const [bars, setBars] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!analyserNode) {
+      setBars(Array(MAX_BARS).fill(-1));
+      return;
+    }
+    const bufferLength = analyserNode.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+
+    const captureAmplitude = () => {
+      analyserNode.getByteTimeDomainData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < bufferLength; i++) {
+        const sample = (dataArray[i] - 128) / 128;
+        sum += sample * sample;
+      }
+      const rms = Math.sqrt(sum / bufferLength);
+      startTransition(() => {
+        setBars((prev) => {
+          const newBars = [...prev, rms];
+          const slicedBars = newBars.slice(-MAX_BARS);
+          if (slicedBars.length < MAX_BARS) {
+            return [
+              ...Array(MAX_BARS - slicedBars.length).fill(-1),
+              ...slicedBars,
+            ];
+          }
+          return slicedBars;
+        });
+      });
+    };
+
+    intervalRef.current = setInterval(captureAmplitude, resolution);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [analyserNode]);
+
+  return (
+    <div className="mt-4 flex h-8 items-center gap-[1px] md:mt-5 max-w-[200px] w-full">
+      {bars.map((amplitude, index) => (
+        <div
+          key={index}
+          className={clsx(
+            'w-[2px]',
+            isPaused
+              ? 'bg-gray-100'
+              : amplitude >= 0
+              ? 'bg-gray-600'
+              : 'bg-gray-200'
+          )}
+          style={{ height: `${clamp(amplitude * scalingFactor, 2, 32)}px` }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/ChatInput/ChatInput/ChatInput.props.ts
+++ b/src/components/ChatInput/ChatInput/ChatInput.props.ts
@@ -89,6 +89,21 @@ export interface ChatInputProps extends ViewProps {
   hideAttachments?: boolean;
 
   /**
+   * Enable audio recording button
+   */
+  enableAudioRecording?: boolean;
+
+  /**
+   * Callback when audio recording starts
+   */
+  onAudioRecordingStart?: () => void;
+
+  /**
+   * Callback when audio recording stops
+   */
+  onAudioRecordingStop?: (audio: Blob) => void;
+
+  /**
    * Title for the chat input
    */
   title?: string;

--- a/src/components/ChatInput/ChatInput/ChatInput.type.ts
+++ b/src/components/ChatInput/ChatInput/ChatInput.type.ts
@@ -72,6 +72,7 @@ export interface ChatInputStyles {
   referenceButton?: ViewProps;
   submitButton?: ViewProps;
   fileButton?: ViewProps;
+  recordButton?: ViewProps;
   modelSelector?: ViewProps;
   loadingIndicator?: ViewProps;
   bottomTip?: ViewProps;

--- a/src/components/ChatInput/ChatInput/ChatInput.view.tsx
+++ b/src/components/ChatInput/ChatInput/ChatInput.view.tsx
@@ -22,6 +22,8 @@ import {
   LoadingSpinnerIcon,
   AttachmentIcon,
 } from '../../Icon/Icon';
+import { AudioRecorder } from '../AudioRecorder';
+import { UploadedFile } from './ChatInput.type';
 
 const ChatInputView: React.FC<ChatInputViewProps> = ({
   // Props from parent
@@ -30,6 +32,7 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
   loading = false,
   disabled = false,
   isAgentRunning = false,
+  enableAudioRecording = false,
   leftButtons,
   rightButtons,
   onStopAgent,
@@ -49,6 +52,8 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
   mentionData = [],
   mentionTrigger = '@',
   onMentionSelect,
+  onAudioRecordingStart,
+  onAudioRecordingStop,
 
   // Props from state
   value,
@@ -298,6 +303,26 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
             marginTop="8px"
           >
             <Horizontal gap={8} alignItems="center">
+              {/* Audio Recorder */}
+              {enableAudioRecording && (
+                <AudioRecorder
+                  onRecordingStart={onAudioRecordingStart}
+                  onRecordingComplete={(file) => {
+                    setPendingFiles((prev) => [...prev, file]);
+                    const uploaded: UploadedFile = {
+                      name: file.name,
+                      path: `/workspace/${file.name}`,
+                      size: file.size,
+                      type: file.type || 'audio/webm',
+                      localUrl: URL.createObjectURL(file),
+                    };
+                    setUploadedFiles((prev) => [...prev, uploaded]);
+                    onAudioRecordingStop?.(file);
+                  }}
+                  views={{ button: views?.recordButton }}
+                />
+              )}
+
               {/* File Upload Button */}
               {!hideAttachments && (
                 <Uploader

--- a/src/components/ChatInput/index.ts
+++ b/src/components/ChatInput/index.ts
@@ -6,3 +6,4 @@ export { GuideTip } from './GuideTip';
 export { PromptExamples } from './PromptExamples';
 export { ReferenceImageButton } from './ReferenceImageButton';
 export { ReferenceImageModal } from './ReferenceImageModal';
+export { AudioRecorder } from './AudioRecorder';

--- a/src/components/ChatInput/useAudioRecording.ts
+++ b/src/components/ChatInput/useAudioRecording.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useAudioRecording() {
+  const [recording, setRecording] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [analyserNode, setAnalyserNode] = useState<AnalyserNode | null>(null);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      if (mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop();
+      }
+      mediaRecorderRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
+    }
+    if (analyserRef.current) {
+      analyserRef.current.disconnect();
+      analyserRef.current = null;
+    }
+    setAnalyserNode(null);
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    cleanup();
+    setError(null);
+    setDuration(0);
+    chunksRef.current = [];
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: 'audio/webm',
+      });
+      mediaRecorderRef.current = mediaRecorder;
+      const audioContext = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
+      audioContextRef.current = audioContext;
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      analyser.smoothingTimeConstant = 0.8;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+      setAnalyserNode(analyser);
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        setAudioBlob(blob);
+      };
+      mediaRecorder.start();
+      setRecording(true);
+      setPaused(false);
+      timerRef.current = setInterval(() => {
+        setDuration((d) => d + 1);
+      }, 1000);
+    } catch {
+      setError('Microphone access denied or unavailable.');
+      cleanup();
+    }
+  }, [cleanup]);
+
+  const stopRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state !== 'inactive'
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+    setRecording(false);
+    setPaused(false);
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const pauseRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === 'recording'
+    ) {
+      mediaRecorderRef.current.pause();
+      setPaused(true);
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, []);
+
+  const resumeRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === 'paused'
+    ) {
+      mediaRecorderRef.current.resume();
+      setPaused(false);
+      if (!timerRef.current) {
+        timerRef.current = setInterval(() => {
+          setDuration((d) => d + 1);
+        }, 1000);
+      }
+    }
+  }, []);
+
+  const resetRecording = useCallback(() => {
+    cleanup();
+    setRecording(false);
+    setPaused(false);
+    setAudioBlob(null);
+    setDuration(0);
+    setError(null);
+    chunksRef.current = [];
+  }, [cleanup]);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  return {
+    recording,
+    paused,
+    audioBlob,
+    analyserNode,
+    duration,
+    error,
+    startRecording,
+    stopRecording,
+    pauseRecording,
+    resumeRecording,
+    resetRecording,
+  };
+}

--- a/src/components/adk/AgentChat/AgentChat/AgentChat.view.tsx
+++ b/src/components/adk/AgentChat/AgentChat/AgentChat.view.tsx
@@ -245,6 +245,9 @@ const AgentChatView: React.FC<AgentChatViewProps> = ({
           loading={isLoading}
           disabled={isLoading}
           hideAttachments={!enableFileUpload}
+          enableAudioRecording={enableAudioRecording}
+          onAudioRecordingStart={props.onAudioRecordingStart}
+          onAudioRecordingStop={props.onAudioRecordingStop}
           views={{
             container: views?.inputField,
           }}


### PR DESCRIPTION
## Summary
- add AudioRecorder component with waveform visual and recording controls
- extend ChatInput and AgentChat to support optional audio recording
- expose recording hook and styles for customization

## Testing
- `npm run lint`
- `npm run test:unwatch` *(fails: ReferenceError: IntersectionObserver is not defined, CSS rule insertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e5a0d548832b85a8bdb6bcb0f1b1