### PR TITLE
fix: enable audio waveform and playback

### DIFF
--- a/src/components/AudioInput/AudioInput/AudioInput.state.ts
+++ b/src/components/AudioInput/AudioInput/AudioInput.state.ts
@@ -20,7 +20,7 @@ export function useAudioInputState(props: AudioInputProps) {
   useEffect(() => {
     if (audioBlob && onAudio) {
       const file = new File([audioBlob], 'recording.webm', {
-        type: audioBlob.type,
+        type: audioBlob.type || 'audio/webm;codecs=opus',
       });
       onAudio(file);
     }

--- a/src/components/AudioInput/AudioWaveform/AudioWaveform.view.tsx
+++ b/src/components/AudioInput/AudioWaveform/AudioWaveform.view.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Element } from 'app-studio';
+import { View } from 'app-studio';
 import { AudioWaveformViewProps } from './AudioWaveform.props';
 
 export function clamp(value: number, min: number, max: number): number {
@@ -26,7 +26,7 @@ export const AudioWaveformView: React.FC<AudioWaveformViewProps> = ({
       {...viewProps}
     >
       {bars.map((amplitude, index) => (
-        <Element
+        <View
           key={index}
           width={2} // Equivalent to w-[2px]
           backgroundColor={

--- a/src/components/ChatInput/AttachmentGroup.tsx
+++ b/src/components/ChatInput/AttachmentGroup.tsx
@@ -97,6 +97,14 @@ export const AttachmentGroup: React.FC<AttachmentGroupProps> = ({
             )}
           </Text>
 
+          {showPreviews && file.type.startsWith('audio/') && (
+            <audio
+              controls
+              src={file.localUrl || file.path}
+              style={{ maxWidth: '200px' }}
+            />
+          )}
+
           {/* Reference button for image files */}
           {onSetAsReference && file.type.startsWith('image/') && (
             <View

--- a/src/components/ChatInput/AudioRecorder.tsx
+++ b/src/components/ChatInput/AudioRecorder.tsx
@@ -29,7 +29,7 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = ({
   useEffect(() => {
     if (audioBlob) {
       const file = new File([audioBlob], `recording-${Date.now()}.webm`, {
-        type: 'audio/webm',
+        type: audioBlob.type || 'audio/webm;codecs=opus',
       });
       onRecordingComplete(file);
     }

--- a/src/components/ChatInput/AudioWaveform/AudioWaveform.view.tsx
+++ b/src/components/ChatInput/AudioWaveform/AudioWaveform.view.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Element } from 'app-studio';
+import { View } from 'app-studio';
 import { AudioWaveformViewProps } from './AudioWaveform.props';
 
 export function clamp(value: number, min: number, max: number): number {
@@ -26,7 +26,7 @@ export const AudioWaveformView: React.FC<AudioWaveformViewProps> = ({
       {...viewProps}
     >
       {bars.map((amplitude, index) => (
-        <Element
+        <View
           key={index}
           width={2} // Equivalent to w-[2px]
           backgroundColor={

--- a/src/components/ChatInput/ChatInput/ChatInput.view.tsx
+++ b/src/components/ChatInput/ChatInput/ChatInput.view.tsx
@@ -264,6 +264,7 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
             sandboxId={sandboxId}
             onRemove={removeUploadedFile}
             onSetAsReference={setFileAsReference}
+            showPreviews={true}
             views={{
               container: views?.attachments,
               item: views?.attachmentItem,
@@ -313,7 +314,7 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
                       name: file.name,
                       path: `/workspace/${file.name}`,
                       size: file.size,
-                      type: file.type || 'audio/webm',
+                      type: file.type || 'audio/webm;codecs=opus',
                       localUrl: URL.createObjectURL(file),
                     };
                     setUploadedFiles((prev) => [...prev, uploaded]);

--- a/src/components/ChatInput/useAudioRecording.ts
+++ b/src/components/ChatInput/useAudioRecording.ts
@@ -17,6 +17,8 @@ export function useAudioRecording() {
   const chunksRef = useRef<Blob[]>([]);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
+  const MIME_TYPE = 'audio/webm;codecs=opus';
+
   const cleanup = useCallback(() => {
     if (mediaRecorderRef.current) {
       if (mediaRecorderRef.current.state !== 'inactive') {
@@ -52,7 +54,7 @@ export function useAudioRecording() {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
       const mediaRecorder = new MediaRecorder(stream, {
-        mimeType: 'audio/webm',
+        mimeType: MIME_TYPE,
       });
       mediaRecorderRef.current = mediaRecorder;
       const audioContext = new (window.AudioContext ||
@@ -71,7 +73,7 @@ export function useAudioRecording() {
         }
       };
       mediaRecorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const blob = new Blob(chunksRef.current, { type: MIME_TYPE });
         setAudioBlob(blob);
       };
       mediaRecorder.start();

--- a/src/hooks/useAudioRecording.ts
+++ b/src/hooks/useAudioRecording.ts
@@ -17,6 +17,8 @@ export function useAudioRecording() {
   const chunksRef = useRef<Blob[]>([]);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
+  const MIME_TYPE = 'audio/webm;codecs=opus';
+
   const cleanup = useCallback(() => {
     if (mediaRecorderRef.current) {
       if (mediaRecorderRef.current.state !== 'inactive') {
@@ -52,7 +54,7 @@ export function useAudioRecording() {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
       const mediaRecorder = new MediaRecorder(stream, {
-        mimeType: 'audio/webm',
+        mimeType: MIME_TYPE,
       });
       mediaRecorderRef.current = mediaRecorder;
       const audioContext = new (window.AudioContext ||
@@ -71,7 +73,7 @@ export function useAudioRecording() {
         }
       };
       mediaRecorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const blob = new Blob(chunksRef.current, { type: MIME_TYPE });
         setAudioBlob(blob);
       };
       mediaRecorder.start();


### PR DESCRIPTION
## Summary
- fix waveform rendering by swapping Element for View
- record audio with explicit `audio/webm;codecs=opus` MIME type
- show audio attachment previews and preserve recording file type

## Testing
- `npm test -- --watchAll=false` *(fails: IntersectionObserver is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa311b44cc832b9d4c1fbb560b9b6a