### PR TITLE
fix: improve audio recording playback

### DIFF
--- a/src/components/AudioInput/AudioInput/AudioInput.view.tsx
+++ b/src/components/AudioInput/AudioInput/AudioInput.view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AudioWaveform } from '../AudioWaveform/AudioWaveform';
 import { AudioInputViewProps } from './AudioInput.props';
 import { View, Horizontal, Button } from 'app-studio'; // Assuming these are from app-studio
@@ -19,10 +19,23 @@ export function AudioInputView({
   handleFileChange,
   ...viewProps
 }: AudioInputViewProps) {
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (audioBlob) {
+      const url = URL.createObjectURL(audioBlob);
+      setAudioUrl(url);
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+    setAudioUrl(null);
+  }, [audioBlob]);
+
   return (
     <View {...viewProps} gap="2">
       <input type="file" accept="audio/*" onChange={handleFileChange} />
-      {recording && (
+      {recording && analyserNode && (
         <AudioWaveform analyserNode={analyserNode} isPaused={paused} />
       )}
       <Horizontal gap="2">
@@ -48,8 +61,8 @@ export function AudioInputView({
           </>
         )}
       </Horizontal>
-      {audioBlob && !recording && (
-        <audio controls src={URL.createObjectURL(audioBlob)} className="mt-2" />
+      {audioUrl && !recording && (
+        <audio controls src={audioUrl} className="mt-2" />
       )}
     </View>
   );

--- a/src/components/ChatInput/AudioRecorder.tsx
+++ b/src/components/ChatInput/AudioRecorder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Horizontal, View } from 'app-studio';
 import { MicrophoneIcon, StopIcon } from '../Icon/Icon';
 import { AudioWaveform } from './AudioWaveform';
@@ -25,6 +25,19 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = ({
     startRecording,
     stopRecording,
   } = useAudioRecording();
+
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (audioBlob) {
+      const url = URL.createObjectURL(audioBlob);
+      setAudioUrl(url);
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+    setAudioUrl(null);
+  }, [audioBlob]);
 
   useEffect(() => {
     if (audioBlob) {
@@ -71,9 +84,10 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = ({
           />
         )}
       </View>
-      {recording && (
+      {recording && analyserNode && (
         <AudioWaveform analyserNode={analyserNode} isPaused={paused} />
       )}
+      {!recording && audioUrl && <audio controls src={audioUrl} />}
     </Horizontal>
   );
 };

--- a/src/components/ChatInput/examples/AudioWaveformChatInput.tsx
+++ b/src/components/ChatInput/examples/AudioWaveformChatInput.tsx
@@ -7,10 +7,7 @@ export const AudioWaveformChatInputDemo = () => {
   const [inputValue, setInputValue] = useState('');
   const [submittedMessage, setSubmittedMessage] = useState('');
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
-  const [isRecording, setIsRecording] = useState(false);
-  const [analyserNode, setAnalyserNode] = useState<AnalyserNode | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const mediaStreamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  // Audio recording is handled internally by ChatInput's AudioRecorder.
 
   const handleSubmit = () => {
     if (inputValue.trim() || uploadedFiles.length > 0) {
@@ -18,36 +15,6 @@ export const AudioWaveformChatInputDemo = () => {
       setInputValue('');
       setUploadedFiles([]);
     }
-  };
-
-  const handleAudioRecordingStart = async () => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      audioContextRef.current = new (window.AudioContext ||
-        (window as any).webkitAudioContext)();
-      mediaStreamSourceRef.current =
-        audioContextRef.current.createMediaStreamSource(stream);
-      const newAnalyserNode = audioContextRef.current.createAnalyser();
-      mediaStreamSourceRef.current.connect(newAnalyserNode);
-      setAnalyserNode(newAnalyserNode);
-      setIsRecording(true);
-    } catch (error) {
-      console.error('Error starting audio recording:', error);
-    }
-  };
-
-  const handleAudioRecordingStop = () => {
-    if (mediaStreamSourceRef.current) {
-      mediaStreamSourceRef.current.disconnect();
-      mediaStreamSourceRef.current.mediaStream
-        .getTracks()
-        .forEach((track) => track.stop());
-    }
-    if (audioContextRef.current) {
-      audioContextRef.current.close();
-    }
-    setAnalyserNode(null);
-    setIsRecording(false);
   };
 
   return (
@@ -84,8 +51,6 @@ export const AudioWaveformChatInputDemo = () => {
             }}
             setPendingFiles={() => {}} // Mock function
             setIsUploading={() => {}} // Mock function
-            onAudioRecordingStart={handleAudioRecordingStart}
-            onAudioRecordingStop={handleAudioRecordingStop}
             getPendingFiles={() => []}
             clearPendingFiles={() => {}}
             onSubmit={handleSubmit}

--- a/src/components/ChatInput/useAudioRecording.ts
+++ b/src/components/ChatInput/useAudioRecording.ts
@@ -73,6 +73,7 @@ export function useAudioRecording() {
       mediaRecorder.onstop = () => {
         const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
         setAudioBlob(blob);
+        cleanup();
       };
       mediaRecorder.start();
       setRecording(true);

--- a/src/hooks/useAudioRecording.ts
+++ b/src/hooks/useAudioRecording.ts
@@ -73,6 +73,7 @@ export function useAudioRecording() {
       mediaRecorder.onstop = () => {
         const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
         setAudioBlob(blob);
+        cleanup();
       };
       mediaRecorder.start();
       setRecording(true);


### PR DESCRIPTION
## Summary
- clean up audio stream after recording to prevent stuck microphone
- keep generated audio URLs stable for playback
- add recorded audio preview in ChatInput and AudioInput components
- remove redundant audio context management in AudioWaveformChatInput demo

## Testing
- `CI=1 npm test 2>&1 | tail -n 20` *(fails: 31 failed, 1 passed, 32 total)*

------
https://chatgpt.com/codex/tasks/task_e_68aa311b44cc832b9d4c1fbb560b9b6a