### PR TITLE
fix: reposition chat audio recorder

### DIFF
--- a/src/components/ChatInput/AudioRecorder.tsx
+++ b/src/components/ChatInput/AudioRecorder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Horizontal, View } from 'app-studio';
 import { MicrophoneIcon, StopIcon } from '../Icon/Icon';
 import { AudioWaveform } from './AudioWaveform';
@@ -25,19 +25,6 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = ({
     startRecording,
     stopRecording,
   } = useAudioRecording();
-
-  const [audioUrl, setAudioUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (audioBlob) {
-      const url = URL.createObjectURL(audioBlob);
-      setAudioUrl(url);
-      return () => {
-        URL.revokeObjectURL(url);
-      };
-    }
-    setAudioUrl(null);
-  }, [audioBlob]);
 
   useEffect(() => {
     if (audioBlob) {
@@ -87,7 +74,6 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = ({
       {recording && analyserNode && (
         <AudioWaveform analyserNode={analyserNode} isPaused={paused} />
       )}
-      {!recording && audioUrl && <audio controls src={audioUrl} />}
     </Horizontal>
   );
 };

--- a/src/components/ChatInput/ChatInput/ChatInput.view.tsx
+++ b/src/components/ChatInput/ChatInput/ChatInput.view.tsx
@@ -108,6 +108,22 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
   // Determine if the submit button should be enabled
   const hasText = (value?.trim().length ?? 0) > 0 || uploadedFiles.length > 0;
 
+  const handleRecordingComplete = React.useCallback(
+    (file: File) => {
+      setPendingFiles((prev) => [...prev, file]);
+      const uploaded: UploadedFile = {
+        name: file.name,
+        path: `/workspace/${file.name}`,
+        size: file.size,
+        type: file.type || 'audio/webm;codecs=opus',
+        localUrl: URL.createObjectURL(file),
+      };
+      setUploadedFiles((prev) => [...prev, uploaded]);
+      onAudioRecordingStop?.(file);
+    },
+    [setPendingFiles, setUploadedFiles, onAudioRecordingStop]
+  );
+
   // Handle multiple file uploads for the Uploader component
   const handleMultipleFileUpload = (files: File[]) => {
     // Filter files that exceed size limit (50MB)
@@ -304,26 +320,6 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
             marginTop="8px"
           >
             <Horizontal gap={8} alignItems="center">
-              {/* Audio Recorder */}
-              {enableAudioRecording && (
-                <AudioRecorder
-                  onRecordingStart={onAudioRecordingStart}
-                  onRecordingComplete={(file) => {
-                    setPendingFiles((prev) => [...prev, file]);
-                    const uploaded: UploadedFile = {
-                      name: file.name,
-                      path: `/workspace/${file.name}`,
-                      size: file.size,
-                      type: file.type || 'audio/webm;codecs=opus',
-                      localUrl: URL.createObjectURL(file),
-                    };
-                    setUploadedFiles((prev) => [...prev, uploaded]);
-                    onAudioRecordingStop?.(file);
-                  }}
-                  views={{ button: views?.recordButton }}
-                />
-              )}
-
               {/* File Upload Button */}
               {!hideAttachments && (
                 <Uploader
@@ -375,6 +371,13 @@ const ChatInputView: React.FC<ChatInputViewProps> = ({
 
             {/* Submit Button */}
             <Horizontal gap={8} alignItems="center">
+              {enableAudioRecording && (
+                <AudioRecorder
+                  onRecordingStart={onAudioRecordingStart}
+                  onRecordingComplete={handleRecordingComplete}
+                  views={{ button: views?.recordButton }}
+                />
+              )}
               <View
                 as="button"
                 type="button"


### PR DESCRIPTION
## Summary
- remove extra audio preview from chat audio recorder
- move recording button next to submit action
- stabilize audio recording handler so each clip appears once and can be deleted

## Testing
- `npm test -- --watchAll=false` *(fails: 30 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7272bd28832bbaf58044b7d35b41