### PR TITLE
feat: enhance attachment previews

### DIFF
--- a/src/components/adk/AgentChat/AgentChat/AgentChat.style.ts
+++ b/src/components/adk/AgentChat/AgentChat/AgentChat.style.ts
@@ -137,17 +137,20 @@ export const DefaultAgentChatStyles = {
   attachmentPreview: {
     position: 'relative',
     display: 'inline-block',
-    padding: '8px',
+    width: '80px',
+    height: '80px',
     backgroundColor: 'color.gray.100',
     borderRadius: '8px',
     border: '1px solid',
     borderColor: 'color.gray.200',
+    overflow: 'hidden',
+    cursor: 'pointer',
   } as ViewProps,
 
   attachmentRemove: {
     position: 'absolute',
-    top: '-4px',
-    right: '-4px',
+    top: '2px',
+    right: '2px',
     width: '20px',
     height: '20px',
     borderRadius: '50%',
@@ -159,6 +162,7 @@ export const DefaultAgentChatStyles = {
     alignItems: 'center',
     justifyContent: 'center',
     fontSize: '12px',
+    zIndex: 1,
   } as ViewProps,
 
   typingIndicator: {

--- a/src/components/adk/AgentChat/AgentChat/AgentMessage.tsx
+++ b/src/components/adk/AgentChat/AgentChat/AgentMessage.tsx
@@ -4,6 +4,7 @@ import { AgentMessage as AgentMessageType } from './AgentChat.props';
 import { DefaultAgentChatStyles } from './AgentChat.style';
 import { Loader } from '../../../Loader/Loader';
 import { Avatar } from '../../../Avatar/Avatar';
+import { MessageAttachmentPreview } from './MessageAttachmentPreview';
 
 export interface AgentMessageProps {
   message: AgentMessageType;
@@ -124,37 +125,7 @@ export const AgentMessage: React.FC<AgentMessageProps> = ({
         {message.attachments && message.attachments.length > 0 && (
           <Horizontal gap={8} flexWrap="wrap">
             {message.attachments.map((attachment, index) => (
-              <View key={index} {...DefaultAgentChatStyles.attachmentPreview}>
-                {attachment.type === 'image' ? (
-                  <img
-                    src={attachment.url}
-                    alt={attachment.file.name}
-                    style={{
-                      width: '60px',
-                      height: '60px',
-                      objectFit: 'cover',
-                      borderRadius: '4px',
-                    }}
-                  />
-                ) : (
-                  <View
-                    width="60px"
-                    height="60px"
-                    backgroundColor="color.gray.200"
-                    borderRadius="4px"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <Text fontSize="xs">📄</Text>
-                  </View>
-                )}
-                <Text fontSize="xs" marginTop={4} textAlign="center">
-                  {attachment.file.name.length > 10
-                    ? attachment.file.name.substring(0, 10) + '...'
-                    : attachment.file.name}
-                </Text>
-              </View>
+              <MessageAttachmentPreview key={index} attachment={attachment} />
             ))}
           </Horizontal>
         )}

--- a/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
+++ b/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { View, Vertical, Text, Button } from 'app-studio';
+import { View, Text, Button } from 'app-studio';
 import { MessageAttachment } from './AgentChat.props';
 import { DefaultAgentChatStyles } from './AgentChat.style';
 
 export interface MessageAttachmentPreviewProps {
   attachment: MessageAttachment;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 /**
@@ -18,98 +18,50 @@ export const MessageAttachmentPreview: React.FC<
 > = ({ attachment, onRemove }) => {
   const { file, url, type } = attachment;
 
-  // Format file size
-  const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  // Open file in a new tab/window
+  const handleOpen = () => {
+    window.open(url, '_blank');
   };
 
-  // Get file icon based on type
-  const getFileIcon = (type: string) => {
-    switch (type) {
-      case 'image':
-        return '🖼️';
-      case 'video':
-        return '🎥';
-      case 'audio':
-        return '🎵';
-      case 'document':
-      default:
-        return '📄';
-    }
+  // Icon for non-image files
+  const getFileIcon = () => {
+    if (type === 'audio' || type === 'video') return '▶️';
+    return '📄';
   };
 
   return (
-    <View {...DefaultAgentChatStyles.attachmentPreview}>
-      {/* Remove button */}
-      <Button
-        {...DefaultAgentChatStyles.attachmentRemove}
-        onClick={onRemove}
-        aria-label={`Remove ${file.name}`}
-      >
-        ×
-      </Button>
+    <View {...DefaultAgentChatStyles.attachmentPreview} onClick={handleOpen}>
+      {onRemove && (
+        <Button
+          {...DefaultAgentChatStyles.attachmentRemove}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          aria-label={`Remove ${file.name}`}
+        >
+          ×
+        </Button>
+      )}
 
-      {/* File preview */}
-      <Vertical gap={8} alignItems="center">
-        {type === 'image' ? (
-          <img
-            src={url}
-            alt={file.name}
-            style={{
-              width: '80px',
-              height: '80px',
-              objectFit: 'cover',
-              borderRadius: '6px',
-            }}
-          />
-        ) : type === 'video' ? (
-          <video
-            src={url}
-            style={{
-              width: '80px',
-              height: '80px',
-              objectFit: 'cover',
-              borderRadius: '6px',
-            }}
-          />
-        ) : (
-          <View
-            width="80px"
-            height="80px"
-            backgroundColor="color.gray.100"
-            borderRadius="6px"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Text fontSize="24px">{getFileIcon(type)}</Text>
-          </View>
-        )}
-
-        {/* File info */}
-        <Vertical gap={2} alignItems="center" maxWidth="120px">
-          <Text
-            fontSize="xs"
-            fontWeight="500"
-            textAlign="center"
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              maxWidth: '100%',
-            }}
-          >
-            {file.name}
-          </Text>
-          <Text fontSize="xs" color="color.gray.500">
-            {formatFileSize(file.size)}
-          </Text>
-        </Vertical>
-      </Vertical>
+      {type === 'image' ? (
+        <img
+          src={url}
+          alt={file.name}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ) : (
+        <View
+          width="100%"
+          height="100%"
+          backgroundColor="color.gray.200"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Text fontSize="24px">{getFileIcon()}</Text>
+        </View>
+      )}
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- show attachments as 80px squares with previews
- allow opening or playing attachments on click
- reuse preview component for message attachments

## Testing
- `npm run lint`
- `npm run test:unwatch` *(fails: 30 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2ad6fb0832b80d5fdd78d23e2bf