### PR TITLE
feat(chat): add media previews

### DIFF
--- a/src/components/ChatInput/AttachmentGroup.tsx
+++ b/src/components/ChatInput/AttachmentGroup.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import { Horizontal, Text, View } from 'app-studio';
 import { UploadedFile } from './ChatInput/ChatInput.type';
 import { ImageIcon, TrashIcon } from '../Icon/Icon';
+import { MediaPreview } from '../MediaPreview';
 import { Button } from '../Button/Button';
 
 interface AttachmentGroupProps {
@@ -54,102 +55,112 @@ export const AttachmentGroup: React.FC<AttachmentGroupProps> = ({
       overflowY="auto"
       {...views?.container}
     >
-      {files.map((file, index) => (
-        <Horizontal
-          key={index}
-          alignItems="center"
-          gap="6px"
-          padding="4px 8px"
-          borderRadius="6px"
-          backgroundColor="color.gray.100"
-          animate={{
-            from: { opacity: 0, scale: 0.9 },
-            to: { opacity: 1, scale: 1 },
-          }}
-          animationDuration={0.2}
-          {...views?.item}
-        >
-          <Text
-            fontWeight="500"
-            color="color.gray.700"
-            maxWidth="120px"
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-            overflow="hidden"
-            {...views?.name}
+      {files.map((file, index) => {
+        const previewUrl = file.localUrl || file.path;
+        const isImage = file.type.startsWith('image/');
+
+        const handleOpen = () => window.open(previewUrl, '_blank');
+
+        return (
+          <Horizontal
+            key={index}
+            alignItems="center"
+            gap="6px"
+            padding="4px 8px"
+            borderRadius="6px"
+            backgroundColor="color.gray.100"
+            animate={{
+              from: { opacity: 0, scale: 0.9 },
+              to: { opacity: 1, scale: 1 },
+            }}
+            animationDuration={0.2}
+            {...views?.item}
           >
-            {file.name}
-          </Text>
-
-          <Text
-            fontSize="10px"
-            color="color.gray.500"
-            flexShrink={0}
-            {...views?.size}
-          >
-            ({formatFileSize(file.size)})
-            {!sandboxId && (
-              <Text as="span" marginLeft="4px" color="theme.primary">
-                (pending)
-              </Text>
-            )}
-          </Text>
-
-          {showPreviews && file.type.startsWith('audio/') && (
-            <audio
-              controls
-              src={file.localUrl || file.path}
-              style={{ maxWidth: '200px' }}
-            />
-          )}
-
-          {/* Reference button for image files */}
-          {onSetAsReference && file.type.startsWith('image/') && (
-            <View
-              as="button"
-              type="button"
-              width="16px"
-              height="16px"
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              borderRadius="50%"
-              backgroundColor={
-                file.isReferenceImage ? 'theme.primary' : 'transparent'
-              }
-              color={file.isReferenceImage ? 'color.white' : 'color.gray.500'}
-              cursor="pointer"
-              transition="all 0.2s ease"
-              onClick={() => onSetAsReference(index)}
-              title={
-                file.isReferenceImage
-                  ? 'Reference image'
-                  : 'Set as reference image'
-              }
-              _hover={{
-                backgroundColor: file.isReferenceImage
-                  ? 'color.blue.600'
-                  : 'color.blue.100',
-                color: file.isReferenceImage ? 'color.white' : 'theme.primary',
-              }}
-              {...views?.referenceButton}
+            <Text
+              fontWeight="500"
+              color="color.gray.700"
+              maxWidth="120px"
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              {...views?.name}
             >
-              <ImageIcon
-                widthHeight={20}
-                color="currentColor"
-                filled={file.isReferenceImage}
-              />
-            </View>
-          )}
+              {file.name}
+            </Text>
 
-          <Button
-            variant="ghost"
-            size="sm"
-            icon={<TrashIcon widthHeight={12} />}
-            onClick={() => onRemove(index)}
-          />
-        </Horizontal>
-      ))}
+            <Text
+              fontSize="10px"
+              color="color.gray.500"
+              flexShrink={0}
+              {...views?.size}
+            >
+              ({formatFileSize(file.size)})
+              {!sandboxId && (
+                <Text as="span" marginLeft="4px" color="theme.primary">
+                  (pending)
+                </Text>
+              )}
+            </Text>
+
+            {showPreviews && (
+              <MediaPreview
+                url={previewUrl}
+                type={file.type}
+                name={file.name}
+                onOpen={handleOpen}
+              />
+            )}
+
+            {/* Reference button for image files */}
+            {onSetAsReference && isImage && (
+              <View
+                as="button"
+                type="button"
+                width="16px"
+                height="16px"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                borderRadius="50%"
+                backgroundColor={
+                  file.isReferenceImage ? 'theme.primary' : 'transparent'
+                }
+                color={file.isReferenceImage ? 'color.white' : 'color.gray.500'}
+                cursor="pointer"
+                transition="all 0.2s ease"
+                onClick={() => onSetAsReference(index)}
+                title={
+                  file.isReferenceImage
+                    ? 'Reference image'
+                    : 'Set as reference image'
+                }
+                _hover={{
+                  backgroundColor: file.isReferenceImage
+                    ? 'color.blue.600'
+                    : 'color.blue.100',
+                  color: file.isReferenceImage
+                    ? 'color.white'
+                    : 'theme.primary',
+                }}
+                {...views?.referenceButton}
+              >
+                <ImageIcon
+                  widthHeight={20}
+                  color="currentColor"
+                  filled={file.isReferenceImage}
+                />
+              </View>
+            )}
+
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<TrashIcon widthHeight={12} />}
+              onClick={() => onRemove(index)}
+            />
+          </Horizontal>
+        );
+      })}
     </View>
   );
 };

--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { View, Image } from 'app-studio';
+import { FileIcon } from './Icon/Icon';
+
+export interface MediaPreviewProps {
+  url: string;
+  type: string; // mime type or generic 'image' | 'video' | 'audio'
+  name?: string;
+  onOpen?: () => void;
+}
+
+/**
+ * MediaPreview renders a square thumbnail for image, video or audio files.
+ * It falls back to a file icon for unsupported types. Clicking the preview
+ * opens the original file unless the user interacts with playback controls.
+ */
+export const MediaPreview: React.FC<MediaPreviewProps> = ({
+  url,
+  type,
+  name,
+  onOpen,
+}) => {
+  const lowerType = type.toLowerCase();
+  const isImage = lowerType.startsWith('image');
+  const isVideo = lowerType.startsWith('video');
+  const isAudio = lowerType.startsWith('audio');
+
+  const handleClick = () => {
+    if (onOpen) {
+      onOpen();
+    }
+  };
+
+  return (
+    <View
+      width="60px"
+      height="60px"
+      flexShrink={0}
+      borderRadius="4px"
+      overflow="hidden"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor="color.gray.200"
+      cursor="pointer"
+      onClick={handleClick}
+    >
+      {isImage && (
+        <Image
+          src={url}
+          alt={name}
+          width="100%"
+          height="100%"
+          objectFit="cover"
+        />
+      )}
+
+      {isVideo && (
+        <View
+          as="video"
+          src={url}
+          controls
+          width="100%"
+          height="100%"
+          style={{ objectFit: 'cover' }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+
+      {isAudio && (
+        <View
+          as="audio"
+          controls
+          src={url}
+          width="100%"
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+
+      {!isImage && !isVideo && !isAudio && (
+        <FileIcon widthHeight={24} color="color.gray.600" />
+      )}
+    </View>
+  );
+};
+
+export default MediaPreview;

--- a/src/components/adk/AgentChat/AgentChat/AgentChat.style.ts
+++ b/src/components/adk/AgentChat/AgentChat/AgentChat.style.ts
@@ -137,8 +137,8 @@ export const DefaultAgentChatStyles = {
   attachmentPreview: {
     position: 'relative',
     display: 'inline-block',
-    width: '80px',
-    height: '80px',
+    width: '60px',
+    height: '60px',
     backgroundColor: 'color.gray.100',
     borderRadius: '8px',
     border: '1px solid',

--- a/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
+++ b/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View, Text, Button } from 'app-studio';
+import { View, Button } from 'app-studio';
 import { MessageAttachment } from './AgentChat.props';
 import { DefaultAgentChatStyles } from './AgentChat.style';
+import { MediaPreview } from '../../../MediaPreview';
 
 export interface MessageAttachmentPreviewProps {
   attachment: MessageAttachment;
@@ -23,14 +24,8 @@ export const MessageAttachmentPreview: React.FC<
     window.open(url, '_blank');
   };
 
-  // Icon for non-image files
-  const getFileIcon = () => {
-    if (type === 'audio' || type === 'video') return '▶️';
-    return '📄';
-  };
-
   return (
-    <View {...DefaultAgentChatStyles.attachmentPreview} onClick={handleOpen}>
+    <View {...DefaultAgentChatStyles.attachmentPreview}>
       {onRemove && (
         <Button
           {...DefaultAgentChatStyles.attachmentRemove}
@@ -44,24 +39,12 @@ export const MessageAttachmentPreview: React.FC<
         </Button>
       )}
 
-      {type === 'image' ? (
-        <img
-          src={url}
-          alt={file.name}
-          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-        />
-      ) : (
-        <View
-          width="100%"
-          height="100%"
-          backgroundColor="color.gray.200"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Text fontSize="24px">{getFileIcon()}</Text>
-        </View>
-      )}
+      <MediaPreview
+        url={url}
+        type={type}
+        name={file.name}
+        onOpen={handleOpen}
+      />
     </View>
   );
 };

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -34,6 +34,7 @@ export * from './Link/Link';
 export * from './Loader/Loader';
 export * from './Uploader/Uploader';
 export * from './Message/Message';
+export * from './MediaPreview';
 export * from './Modal/Modal';
 export * from './NavigationMenu/NavigationMenu';
 export * from './Table/Table';


### PR DESCRIPTION
## Summary
- centralize attachment rendering with new `MediaPreview` component
- reuse consistent 60px thumbnails for uploads and sent message attachments
- expose `MediaPreview` from component index for broader use

## Testing
- `npm run lint`
- `npm test -- --watchAll=false` *(fails: 30 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab028c8094832bb3e8b601b7965923