### PR TITLE
feat: show media thumbnails in attachment group

### DIFF
--- a/src/components/ChatInput/AttachmentGroup.tsx
+++ b/src/components/ChatInput/AttachmentGroup.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Horizontal, Text, Vertical, View } from 'app-studio';
+import { Horizontal, Text, Vertical, View, Image, Center } from 'app-studio';
 import { UploadedFile } from './ChatInput/ChatInput.type';
-import { ImageIcon } from '../Icon/Icon';
-import { MediaPreview } from '../MediaPreview';
+import { ImageIcon, FileIcon, AudioIcon } from '../Icon/Icon';
 import { HoverCard } from '../HoverCard/HoverCard';
 
 interface AttachmentGroupProps {
@@ -58,8 +57,8 @@ export const AttachmentGroup: React.FC<AttachmentGroupProps> = ({
       {files.map((file, index) => {
         const previewUrl = file.localUrl || file.path;
         const isImage = file.type.startsWith('image/');
-
-        const handleOpen = () => window.open(previewUrl, '_blank');
+        const isVideo = file.type.startsWith('video/');
+        const isAudio = file.type.startsWith('audio/');
 
         return (
           <Vertical
@@ -87,15 +86,58 @@ export const AttachmentGroup: React.FC<AttachmentGroupProps> = ({
             {showPreviews && (
               <HoverCard>
                 <HoverCard.Trigger>
-                  <MediaPreview
-                    url={previewUrl}
-                    type={file.type}
-                    name={file.name}
-                    onOpen={handleOpen}
-                  />
+                  {isImage && (
+                    <Image
+                      src={previewUrl}
+                      alt={file.name}
+                      width="60px"
+                      height="60px"
+                      objectFit="cover"
+                    />
+                  )}
+                  {isVideo && (
+                    <View
+                      as="video"
+                      src={previewUrl}
+                      width="60px"
+                      height="60px"
+                      style={{ objectFit: 'cover' }}
+                      muted
+                    />
+                  )}
+                  {isAudio && (
+                    <Center
+                      width="60px"
+                      height="60px"
+                      backgroundColor="color.gray.200"
+                    >
+                      <AudioIcon widthHeight={24} color="color.gray.600" />
+                    </Center>
+                  )}
+                  {!isImage && !isVideo && !isAudio && (
+                    <Center
+                      width="60px"
+                      height="60px"
+                      backgroundColor="color.gray.200"
+                    >
+                      <FileIcon widthHeight={24} color="color.gray.600" />
+                    </Center>
+                  )}
                 </HoverCard.Trigger>
                 <HoverCard.Content>
-                  <Text>
+                  {isImage && (
+                    <Image src={previewUrl} alt={file.name} maxWidth="300px" />
+                  )}
+                  {isVideo && (
+                    <View
+                      as="video"
+                      src={previewUrl}
+                      controls
+                      style={{ maxWidth: '300px' }}
+                    />
+                  )}
+                  {isAudio && <View as="audio" src={previewUrl} controls />}
+                  <Text marginTop="4px">
                     {file.name} ({formatFileSize(file.size)})
                   </Text>
                 </HoverCard.Content>

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -293,6 +293,36 @@ export const ImageIcon: React.FC<IconProps> = ({
   </IconWrapper>
 );
 
+// Audio/Speaker Icon Component
+export const AudioIcon: React.FC<IconProps> = ({
+  widthHeight = 24,
+  color = 'currentColor',
+  filled = true,
+  strokeWidth = 1,
+  ...props
+}) => (
+  <IconWrapper widthHeight={widthHeight} color={color} {...props}>
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M11 5l-5 5H2v4h4l5 5V5z"
+        {...getSvgProps(filled, color, strokeWidth)}
+      />
+      <path
+        d="M15.54 8.46a5 5 0 0 1 0 7.07"
+        {...getSvgProps(false, color, strokeWidth)}
+      />
+      <path
+        d="M18.07 5.93a8 8 0 0 1 0 12.14"
+        {...getSvgProps(false, color, strokeWidth)}
+      />
+    </svg>
+  </IconWrapper>
+);
+
 export const TwitterIcon: React.FC<IconProps> = ({
   widthHeight = 24,
   color = 'currentColor',

--- a/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
+++ b/src/components/adk/AgentChat/AgentChat/MessageAttachmentPreview.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { View, Button } from 'app-studio';
+import { View, Button, Image, Center } from 'app-studio';
 import { MessageAttachment } from './AgentChat.props';
 import { DefaultAgentChatStyles } from './AgentChat.style';
-import { MediaPreview } from '../../../MediaPreview';
+import { HoverCard } from '../../../HoverCard/HoverCard';
+import { FileIcon, AudioIcon } from '../../../Icon/Icon';
 
 export interface MessageAttachmentPreviewProps {
   attachment: MessageAttachment;
@@ -18,11 +19,10 @@ export const MessageAttachmentPreview: React.FC<
   MessageAttachmentPreviewProps
 > = ({ attachment, onRemove }) => {
   const { file, url, type } = attachment;
-
-  // Open file in a new tab/window
-  const handleOpen = () => {
-    window.open(url, '_blank');
-  };
+  const lowerType = type.toLowerCase();
+  const isImage = lowerType.startsWith('image/');
+  const isVideo = lowerType.startsWith('video/');
+  const isAudio = lowerType.startsWith('audio/');
 
   return (
     <View {...DefaultAgentChatStyles.attachmentPreview}>
@@ -39,12 +39,46 @@ export const MessageAttachmentPreview: React.FC<
         </Button>
       )}
 
-      <MediaPreview
-        url={url}
-        type={type}
-        name={file.name}
-        onOpen={handleOpen}
-      />
+      <HoverCard>
+        <HoverCard.Trigger>
+          {isImage && (
+            <Image
+              src={url}
+              alt={file.name}
+              width="60px"
+              height="60px"
+              objectFit="cover"
+            />
+          )}
+          {isVideo && (
+            <View
+              as="video"
+              src={url}
+              width="60px"
+              height="60px"
+              style={{ objectFit: 'cover' }}
+              muted
+            />
+          )}
+          {isAudio && (
+            <Center width="60px" height="60px" backgroundColor="color.gray.200">
+              <AudioIcon widthHeight={24} color="color.gray.600" />
+            </Center>
+          )}
+          {!isImage && !isVideo && !isAudio && (
+            <Center width="60px" height="60px" backgroundColor="color.gray.200">
+              <FileIcon widthHeight={24} color="color.gray.600" />
+            </Center>
+          )}
+        </HoverCard.Trigger>
+        <HoverCard.Content>
+          {isImage && <Image src={url} alt={file.name} maxWidth="300px" />}
+          {isVideo && (
+            <View as="video" src={url} controls style={{ maxWidth: '300px' }} />
+          )}
+          {isAudio && <View as="audio" src={url} controls />}
+        </HoverCard.Content>
+      </HoverCard>
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- show image and video thumbnails with hover previews
- use audio icon for audio files and reveal player on hover
- add reusable AudioIcon

## Testing
- `npm run test:unwatch` *(fails: 30 failed, 2 passed)*
- `npm test src/__tests__/title.test.tsx -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ab15800388832b980014a6dfcf897d