### PR TITLE
Add status indicator and progress bar component pages

### DIFF
--- a/src/components/ProgressBar/examples/default.tsx
+++ b/src/components/ProgressBar/examples/default.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { ProgressBar } from '../ProgressBar';
+
+export const DefaultDemo = () => <ProgressBar value={50} />;

--- a/src/components/ProgressBar/examples/index.ts
+++ b/src/components/ProgressBar/examples/index.ts
@@ -1,0 +1,2 @@
+export * from './default';
+export * from './styles';

--- a/src/components/ProgressBar/examples/styles.tsx
+++ b/src/components/ProgressBar/examples/styles.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { ProgressBar } from '../ProgressBar';
+
+export const StyleDemo = () => (
+  <ProgressBar value={70} color="color.green.500" height={12} radius={6} />
+);

--- a/src/components/StatusIndicator/examples/default.tsx
+++ b/src/components/StatusIndicator/examples/default.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { StatusIndicator } from '../StatusIndicator';
+
+export const DefaultDemo = () => (
+  <StatusIndicator label="Active" status="success" />
+);

--- a/src/components/StatusIndicator/examples/index.ts
+++ b/src/components/StatusIndicator/examples/index.ts
@@ -1,0 +1,2 @@
+export * from './default';
+export * from './statuses';

--- a/src/components/StatusIndicator/examples/statuses.tsx
+++ b/src/components/StatusIndicator/examples/statuses.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View } from 'app-studio';
+import { StatusIndicator } from '../StatusIndicator';
+
+export const StatusVariants = () => (
+  <View gap={8}>
+    <StatusIndicator label="Info" status="info" />
+    <StatusIndicator label="Success" status="success" />
+    <StatusIndicator label="Warning" status="warning" />
+    <StatusIndicator label="Error" status="error" />
+  </View>
+);

--- a/src/pages/components.page.tsx
+++ b/src/pages/components.page.tsx
@@ -51,12 +51,16 @@ const NavigationMenuPage = lazy(() => import('src/pages/navigationMenu.page'));
 const OTPInputPage = lazy(() => import('src/pages/otpInput.page'));
 const PaginationPage = lazy(() => import('src/pages/pagination.page'));
 const PasswordPage = lazy(() => import('src/pages/password.page'));
+const ProgressBarPage = lazy(() => import('src/pages/progressBar.page'));
 const SelectPage = lazy(() => import('src/pages/select.page'));
 const SeparatorPage = lazy(() => import('src/pages/separator.page'));
 const ResizablePage = lazy(() => import('src/pages/resizable.page'));
 const SidebarPage = lazy(() => import('src/pages/sidebar.page'));
 const SliderPage = lazy(() => import('src/pages/slider.page'));
 const SwitchPage = lazy(() => import('src/pages/switch.page'));
+const StatusIndicatorPage = lazy(
+  () => import('src/pages/statusIndicator.page')
+);
 const TablePage = lazy(() => import('src/pages/table.page'));
 const TabsPage = lazy(() => import('src/pages/tabs.page'));
 const TextPage = lazy(() => import('src/pages/text.page'));
@@ -138,11 +142,17 @@ export const componentList = [
   { name: 'OTP Input', path: '/otpinput', element: <OTPInputPage /> },
   { name: 'Pagination', path: '/pagination', element: <PaginationPage /> },
   { name: 'Password', path: '/password', element: <PasswordPage /> },
+  { name: 'ProgressBar', path: '/progress-bar', element: <ProgressBarPage /> },
   { name: 'Resizable', path: '/resizable', element: <ResizablePage /> },
   { name: 'Select', path: '/select', element: <SelectPage /> },
   { name: 'Separator', path: '/separator', element: <SeparatorPage /> },
   { name: 'Sidebar', path: '/sidebar', element: <SidebarPage /> },
   { name: 'Slider', path: '/slider', element: <SliderPage /> },
+  {
+    name: 'StatusIndicator',
+    path: '/status-indicator',
+    element: <StatusIndicatorPage />,
+  },
 
   { name: 'Switch', path: '/switch', element: <SwitchPage /> },
   { name: 'Table', path: '/table', element: <TablePage /> },

--- a/src/pages/progressBar.page.tsx
+++ b/src/pages/progressBar.page.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View } from 'app-studio';
+import { DefaultDemo, StyleDemo } from 'src/components/ProgressBar/examples';
+
+const ProgressBarPage = () => {
+  return (
+    <View>
+      <table>
+        <tbody>
+          <tr>
+            <th>Property</th>
+            <th>App-Studio</th>
+          </tr>
+          <tr>
+            <td>Default</td>
+            <td>
+              <DefaultDemo />
+            </td>
+          </tr>
+          <tr>
+            <td>Styles</td>
+            <td>
+              <StyleDemo />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </View>
+  );
+};
+
+export default ProgressBarPage;

--- a/src/pages/statusIndicator.page.tsx
+++ b/src/pages/statusIndicator.page.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View } from 'app-studio';
+import {
+  DefaultDemo,
+  StatusVariants,
+} from 'src/components/StatusIndicator/examples';
+
+const StatusIndicatorPage = () => {
+  return (
+    <View>
+      <table>
+        <tbody>
+          <tr>
+            <th>Property</th>
+            <th>App-Studio</th>
+          </tr>
+          <tr>
+            <td>Default</td>
+            <td>
+              <DefaultDemo />
+            </td>
+          </tr>
+          <tr>
+            <td>Statuses</td>
+            <td>
+              <StatusVariants />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </View>
+  );
+};
+
+export default StatusIndicatorPage;


### PR DESCRIPTION
## Summary
- add ProgressBar examples and component page
- add StatusIndicator examples and page
- register new pages in the component navigator

## Testing
- `npm test` *(fails: 32 failed, 2 passed, 34 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc66abcab8832baebf51d2b1a93e1e