### PR TITLE
feat: add video background variant

### DIFF
--- a/src/components/Background/Background.tsx
+++ b/src/components/Background/Background.tsx
@@ -47,6 +47,12 @@ import { BackgroundView } from './Background/Background.view';
  * </Background.Image>
  *
  * @example
+ * // Background Video
+ * <Background.Video src="/path/to/video.mp4" overlay="rgba(0,0,0,0.5)">
+ *   <Text color="white">Content over video</Text>
+ * </Background.Video>
+ *
+ * @example
  * // Background Gradient
  * <Background.Gradient from="blue.500" to="purple.500" animate={true}>
  *   <Text color="white">Content over gradient</Text>
@@ -66,6 +72,7 @@ export const Background = Object.assign(BackgroundComponent, {
   Grid: BackgroundView.Grid,
   Ripples: BackgroundView.Ripples,
   Image: BackgroundView.Image,
+  Video: BackgroundView.Video,
   Gradient: BackgroundView.Gradient,
 });
 

--- a/src/components/Background/Background/Background.props.ts
+++ b/src/components/Background/Background/Background.props.ts
@@ -137,6 +137,62 @@ export interface BackgroundImageProps
 }
 
 /**
+ * Background Video component props
+ */
+export interface BackgroundVideoProps
+  extends Omit<BackgroundProps, 'position'> {
+  /**
+   * Video source URL
+   */
+  src: string;
+
+  /**
+   * Whether the video should autoplay
+   * @default true
+   */
+  autoPlay?: boolean;
+
+  /**
+   * Whether the video should loop
+   * @default true
+   */
+  loop?: boolean;
+
+  /**
+   * Whether the video should be muted
+   * @default true
+   */
+  muted?: boolean;
+
+  /**
+   * Use inline playback on mobile
+   * @default true
+   */
+  playsInline?: boolean;
+
+  /**
+   * Overlay color to blend with video
+   */
+  overlay?: string;
+
+  /**
+   * Blend mode for overlay
+   * @default 'normal'
+   */
+  blendMode?: BlendMode;
+
+  /**
+   * Custom views for styling
+   */
+  views?: {
+    container?: ViewProps;
+    content?: ViewProps;
+    video?: ViewProps;
+    overlay?: ViewProps;
+  };
+}
+
+/**
  * Background Gradient component props
  * Extends GradientProps and adds Background-specific functionality
  */
@@ -153,5 +209,7 @@ export interface BackgroundStyles {
   aurora?: ViewProps;
   meteors?: ViewProps;
   image?: ViewProps;
+  video?: ViewProps;
+  overlay?: ViewProps;
   gradient?: ViewProps;
 }

--- a/src/components/Background/Background/Background.style.ts
+++ b/src/components/Background/Background/Background.style.ts
@@ -83,6 +83,43 @@ export const BackgroundImageStyles = {
 };
 
 /**
+ * Background Video styles
+ */
+export const BackgroundVideoStyles = {
+  container: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  } as ViewProps,
+
+  video: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  } as ViewProps,
+
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    pointerEvents: 'none',
+  } as ViewProps,
+
+  content: {
+    position: 'relative',
+    zIndex: 2,
+  } as ViewProps,
+};
+
+/**
  * Meteors effect styles
  */
 export const MeteorsStyles = {

--- a/src/components/Background/Background/Background.type.ts
+++ b/src/components/Background/Background/Background.type.ts
@@ -11,6 +11,7 @@ export type BackgroundEffect =
   | 'ripples'
   | 'wall'
   | 'image'
+  | 'video'
   | 'gradient'
   | 'borderMoving'
   | 'animatedStroke';

--- a/src/components/Background/Background/Background.view.tsx
+++ b/src/components/Background/Background/Background.view.tsx
@@ -9,12 +9,14 @@ import {
   GridProps,
   RipplesProps,
   BackgroundImageProps,
+  BackgroundVideoProps,
   BackgroundGradientProps,
 } from './Background.props';
 import {
   DefaultBackgroundStyles,
   AuroraStyles,
   BackgroundImageStyles,
+  BackgroundVideoStyles,
 } from './Background.style';
 import { BackgroundContextType } from './Background.type';
 import { Gradient } from '../../Gradient/Gradient';
@@ -562,6 +564,57 @@ const BackgroundImage: React.FC<BackgroundImageProps> = ({
 };
 
 /**
+ * Background Video Component
+ */
+const BackgroundVideo: React.FC<BackgroundVideoProps> = ({
+  children,
+  src,
+  autoPlay = true,
+  loop = true,
+  muted = true,
+  playsInline = true,
+  overlay,
+  blendMode = 'normal',
+  views,
+  themeMode: elementMode,
+  ...props
+}) => {
+  const { getColor } = useTheme();
+
+  const overlayStyle: React.CSSProperties = overlay
+    ? {
+        ...BackgroundVideoStyles.overlay,
+        backgroundColor: getColor(
+          overlay,
+          elementMode ? { themeMode: elementMode } : undefined
+        ),
+        mixBlendMode: blendMode as any,
+      }
+    : {};
+
+  return (
+    <View {...BackgroundVideoStyles.container} {...views?.container} {...props}>
+      <View
+        as="video"
+        src={src}
+        autoPlay={autoPlay}
+        loop={loop}
+        muted={muted}
+        playsInline={playsInline}
+        style={BackgroundVideoStyles.video as React.CSSProperties}
+        {...views?.video}
+      />
+      {overlay && <View style={overlayStyle} {...views?.overlay} />}
+      {children && (
+        <View {...BackgroundVideoStyles.content} {...views?.content}>
+          {children}
+        </View>
+      )}
+    </View>
+  );
+};
+
+/**
  * Background Gradient Component
  * Uses the existing Gradient component as a background
  */
@@ -583,6 +636,7 @@ interface BackgroundViewComponent extends React.FC<BackgroundProps> {
   Grid: React.FC<GridProps>;
   Ripples: React.FC<RipplesProps>;
   Image: React.FC<BackgroundImageProps>;
+  Video: React.FC<BackgroundVideoProps>;
   Gradient: React.FC<BackgroundGradientProps>;
 }
 
@@ -615,4 +669,5 @@ BackgroundView.Particles = Particles;
 BackgroundView.Grid = Grid;
 BackgroundView.Ripples = Ripples;
 BackgroundView.Image = BackgroundImage;
+BackgroundView.Video = BackgroundVideo;
 BackgroundView.Gradient = BackgroundGradient;

--- a/src/components/Background/README.md
+++ b/src/components/Background/README.md
@@ -6,6 +6,7 @@ A comprehensive collection of background effects for creating engaging visual ex
 
 - **Animated Effects**: Aurora, Meteors, Particles, Grid, Ripples, Wall
 - **Background Images**: Support for images with overlays and blend modes
+- **Background Videos**: Play videos as immersive backgrounds
 - **Gradient Backgrounds**: Linear, radial, and conic gradients with animation
 - **Theme Integration**: Full support for app-studio color system
 - **Responsive Design**: Works seamlessly with responsive layouts
@@ -29,6 +30,11 @@ import { Background } from '@app-studio/web';
 >
   <Text color="white">Image Background</Text>
 </Background.Image>
+
+// Background video with overlay
+<Background.Video src="/hero-video.mp4" overlay="rgba(0,0,0,0.4)">
+  <Text color="white">Video Background</Text>
+</Background.Video>
 
 // Animated gradient
 <Background.Gradient
@@ -57,6 +63,7 @@ import { Background } from '@app-studio/web';
 
 ### Background Types
 - `Background.Image` - Image backgrounds with overlay support
+- `Background.Video` - Video backgrounds with overlay support
 - `Background.Gradient` - Gradient backgrounds with animation
 
 ### Interactive Elements
@@ -68,6 +75,12 @@ import { Background } from '@app-studio/web';
 ### Background.Image
 - `src` - Image source URL (required)
 - `backgroundSize` - Image sizing ('cover', 'contain', etc.)
+- `overlay` - Color or gradient overlay
+- `blendMode` - CSS blend mode for overlay
+
+### Background.Video
+- `src` - Video source URL (required)
+- `autoPlay/loop/muted` - Video playback controls
 - `overlay` - Color or gradient overlay
 - `blendMode` - CSS blend mode for overlay
 

--- a/src/components/Background/examples/index.ts
+++ b/src/components/Background/examples/index.ts
@@ -6,3 +6,4 @@ export { ParticlesDemo } from './particles';
 export { GridDemo } from './grid';
 export { RipplesDemo } from './ripples';
 export { CombinedEffectsDemo } from './combinedEffects';
+export { VideoDemo } from './video';

--- a/src/components/Background/examples/video.tsx
+++ b/src/components/Background/examples/video.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Background } from '../Background';
+import { Vertical } from 'app-studio';
+import { Text } from '../../Text/Text';
+
+export const VideoDemo = () => (
+  <Vertical gap={16}>
+    <Text fontSize={16} fontWeight="600">
+      Video Background
+    </Text>
+    <Background.Video
+      src="https://www.w3schools.com/html/mov_bbb.mp4"
+      height="200px"
+      overlay="rgba(0,0,0,0.3)"
+    >
+      <Text color="white" fontSize={18} fontWeight="500">
+        Video Background
+      </Text>
+    </Background.Video>
+  </Vertical>
+);
+
+export default VideoDemo;

--- a/src/components/Background/index.ts
+++ b/src/components/Background/index.ts
@@ -8,6 +8,7 @@ export type {
   GridProps,
   RipplesProps,
   BackgroundImageProps,
+  BackgroundVideoProps,
   BackgroundGradientProps,
   BackgroundStyles,
 } from './Background/Background.props';


### PR DESCRIPTION
## Summary
- add `Background.Video` variant for playing full-bleed videos with optional overlay
- document video backgrounds and provide example usage
- export `BackgroundVideoProps` types and styles

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '../../../hooks/useAudioRecording')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6617df08832baa2dc4dc32600d1e