### PR TITLE
feat: compute Text color from background

### DIFF
--- a/src/components/Text/Text/Text.props.ts
+++ b/src/components/Text/Text/Text.props.ts
@@ -3,6 +3,7 @@ import { Headings, Size, TextWeights } from './Text.type';
 export interface TextProps
   extends Omit<TextAppProps, 'children' | 'style' | 'pointerEvents'> {
   children?: React.ReactNode;
+  backgroundColor?: string;
   heading?: Headings;
   isItalic?: boolean;
   isStriked?: boolean;

--- a/src/components/Text/Text/Text.utils.ts
+++ b/src/components/Text/Text/Text.utils.ts
@@ -1,0 +1,25 @@
+export const getTextColorHex = (backgroundColor: string) => {
+  // Simple luminance calculation to determine text color contrast
+  const color = backgroundColor.replace('#', '');
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.4 ? 'black' : 'white';
+};
+
+export const getTextColor = (backgroundColor: string) => {
+  // Use complementary color for better contrast and return as hex
+  const color = backgroundColor.replace('#', '');
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+
+  // Calculate the complementary color
+  const complementR = (255 - r).toString(16).padStart(2, '0');
+  const complementG = (255 - g).toString(16).padStart(2, '0');
+  const complementB = (255 - b).toString(16).padStart(2, '0');
+
+  // Return the color in hex format
+  return getTextColorHex(`#${complementR}${complementG}${complementB}`);
+};

--- a/src/components/Text/Text/Text.view.tsx
+++ b/src/components/Text/Text/Text.view.tsx
@@ -14,6 +14,7 @@ import {
   LineHeights,
   FontWeights,
 } from './Text.style';
+import { getTextColor } from './Text.utils';
 
 interface Props extends TextProps {
   views?: {
@@ -198,6 +199,8 @@ const TextView: React.FC<Props> = ({
   isStriked = false,
   weight = 'normal',
   size = 'md',
+  backgroundColor,
+  color,
   views,
   ...props
 }) => {
@@ -212,6 +215,9 @@ const TextView: React.FC<Props> = ({
   const lineHeight = LineHeights[size];
   const fontWeight = FontWeights[weight];
 
+  const computedColor =
+    color ?? (backgroundColor ? getTextColor(backgroundColor) : undefined);
+
   return (
     <Element
       // Apply typography styles according to design guidelines
@@ -223,6 +229,7 @@ const TextView: React.FC<Props> = ({
       textDecoration={
         isStriked ? 'line-through' : isUnderlined ? 'underline' : 'none'
       }
+      color={computedColor}
       // Apply layout styles
       {...noLineBreak}
       // Apply heading styles if specified


### PR DESCRIPTION
## Summary
- add an optional `backgroundColor` prop to the Text component
- derive the rendered text color from the provided background color using new utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd1767648c832bad9203f688f69106