### PR TITLE
fix(button): support multiline animated stroke

### DIFF
--- a/src/components/Button/Button/Button.view.tsx
+++ b/src/components/Button/Button/Button.view.tsx
@@ -277,6 +277,7 @@ const ButtonView: React.FC<ButtonProps> = ({
       >
         <View
           as="svg"
+          display="block"
           height={numericHeight}
           width={numericWidth}
           xmlns="http://www.w3.org/2000/svg"
@@ -299,12 +300,23 @@ const ButtonView: React.FC<ButtonProps> = ({
         </View>
 
         <View
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          paddingX={16}
+          paddingY={8}
           fontSize="22px"
-          lineHeight="32px"
+          lineHeight="1.3"
           letterSpacing="0.3rem"
-          position="relative"
-          top="-48px"
+          textAlign="center"
           textTransform="uppercase"
+          whiteSpace="normal"
+          wordBreak="break-word"
           pointerEvents="none"
           userSelect="none"
           color={resolvedTextColor}


### PR DESCRIPTION
## Summary
- position animated stroke label absolutely so it centers content without relying on fixed offsets
- allow multiline animated stroke button text by enabling wrapping and centered flex layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd2b6be3e0832b97b17a8c1fd9fbaf